### PR TITLE
move from using project_name to project_id

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,7 +12,7 @@ The service account key of google cloud. The service accout json file must be en
 ### `registry`
 The registry where the image should be pushed. Default `gcr.io`.
 
-### `project_name`
+### `project_id`
 The project name. This field is required.
 
 ### `image_name`
@@ -52,7 +52,7 @@ jobs:
         with:
           gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
           registry: gcr.io
-          project_name: my-awesome-project
+          project_id: my-awesome-project
           image_name: server-end
 
 ```
@@ -75,7 +75,7 @@ jobs:
         with:
           gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
           registry: gcr.io
-          project_name: my-awesome-project
+          project_id: my-awesome-project
           image_name: server-end
           image_tag: ${{ steps.get_tag_name.outputs.GIT_TAG_NAME}}
           dockerfile: ./build/Dockerfile

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ inputs:
     description: The registry where the image should be pushed
     required: false
     default: gcr.io
-  project_name:
-    description: The project name
+  project_id:
+    description: The project id
     required: true
     default: my-awesome-project
   image_name:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@
 #date           :20200703
 #version        :2.0.0
 #usage          :./entrypoint.sh
-#notes          :Required env values are: INPUT_GCLOUD_SERVICE_KEY,INPUT_REGISTRY,INPUT_PROJECT_NAME,INPUT_IMAGE_NAME
+#notes          :Required env values are: INPUT_GCLOUD_SERVICE_KEY,INPUT_REGISTRY,INPUT_PROJECT_ID,INPUT_IMAGE_NAME
 #                Optional env values are: INPUT_IMAGE_TAG,INPUT_DOCKERFILE,INPUT_TARGET,INPUT_CONTEXT
 #bash_version   :5.0.17(1)-release
 ###################################################
@@ -54,7 +54,7 @@ fi
 
 for IMAGE_TAG in ${ALL_IMAGE_TAG[@]}; do
 
-    IMAGE_NAME="$INPUT_REGISTRY/$INPUT_PROJECT_NAME/$INPUT_IMAGE_NAME:$IMAGE_TAG"
+    IMAGE_NAME="$INPUT_REGISTRY/$INPUT_PROJECT_ID/$INPUT_IMAGE_NAME:$IMAGE_TAG"
 
     echo "Fully qualified image name: $IMAGE_NAME"
 

--- a/example/build.yml
+++ b/example/build.yml
@@ -8,5 +8,5 @@ jobs:
         with:
           gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
           registry: gcr.io
-          project_name: my-awesome-project
+          project_id: my-awesome-project
           image_name: server-end

--- a/example/build_all_option.yml
+++ b/example/build_all_option.yml
@@ -8,7 +8,7 @@ jobs:
         with:
           gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
           registry: gcr.io
-          project_name: my-awesome-project
+          project_id: my-awesome-project
           image_name: server-end
           image_tag: latest,v1
           dockerfile: ./docker/Dockerfile.prod

--- a/example/build_only_tags.yml
+++ b/example/build_only_tags.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
         registry: gcr.io
-        project_name: my-awesome-project
+        project_id: my-awesome-project
         image_name: server-end
         image_tag: latest,${{ steps.get_tag_name.outputs.GIT_TAG_NAME }}
         dockerfile: ./build/Dockerfile

--- a/test/ReadMe.md
+++ b/test/ReadMe.md
@@ -5,5 +5,5 @@ To test the action locally, [https://github.com/nektos/act](https://github.com/n
 ## Steps:
 
 1. Create a `secret.txt` file with the `base64` representation of GCloud Service Account json key in `./test` folder.
-2. Change `project_name`, `image_name`, `image_tag` in the `./test/build.yml` as your GCP project. 
+2. Change `project_id`, `image_name`, `image_tag` in the `./test/build.yml` as your GCP project. 
 2. Run `act -v -s GCLOUD_SERVICE_KEY="$(< test/secret.txt)" -W test/` from the repository root.

--- a/test/build.yml
+++ b/test/build.yml
@@ -8,7 +8,7 @@ jobs:
         with:
           gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
           registry: gcr.io
-          project_name: source-code-oj
+          project_id: source-code-oj
           image_name: push-to-gcr-action-test
           image_tag: v2,latest
           dockerfile: ./test/Dockerfile.test


### PR DESCRIPTION
Using project_name is a little bit misleading as it actually needs to be the project_id which some times is not always the same as the project_name.
I tested this using project_id instead of project_name and it works.


Signed-off-by: David O'Dell <davidodell@gmail.com>