### PR TITLE
feat: support multiple image push

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,8 +18,12 @@ inputs:
     default: my-awesome-project
   image_name:
     description: The image name
-    required: true
-    default: backend-server
+    required: false
+    default: ""
+  all_prefixed_images:
+    description: Push all local images under the '$registry/$project_id/*' prefix. Expects that `image_name` be left blank and `push_only`=true.
+    required: false
+    default: false
   image_tag:
     description: Tag name
     required: false


### PR DESCRIPTION
Hey @RafikFarhad! So, I'm digging this project, but it doesn't quite support my use-case, or at least, I think I'd need to get creative to make it work.

I'm in a monorepo context, and currently I've got one job building N images associated to N separate component services. Whether or not that's the "right" approach, it's currently my "fast" approach.

What the change I am proposing would do is introduce a boolean flag `all_prefixed_images`, which, when set, scrapes the local `docker` daemon for everything that has been created and is bound for your $registry/$project-id domain. *Those* images are then slated for push.

This is an early-stage draft, my testing completion status is pretty minimal right now:
[X] verify locally with the `docker images --filter --format` stuff & env variables
[ ] build a real test case

I'm mostly panning to see whether or not you want this in your repo.

Let me know, and keep up the awesome work!