### PR TITLE
Fix example in ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -66,6 +66,9 @@ on: [push]
 jobs:
   build-and-push-to-gcr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:      
       - uses: actions/checkout@v3
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
In [`build-and-push.yml`](https://github.com/RafikFarhad/push-to-gcr-github-action/blob/master/.github/workflows/build_and_push.yaml) there are permissions set on line 14-16 when auth with workload identity

https://github.com/RafikFarhad/push-to-gcr-github-action/blob/658acb5f95b53e255ef36ec3b1e296b174650fbf/.github/workflows/build_and_push.yaml#L14-L16

This setting is not included in the example in ReadMe.md, and when I used the example config, this error occurred: 

```
Run google-github-actions/auth@v0
  with:
    workload_identity_provider: <my-provider>
    service_account: <my-service-account>
    create_credentials_file: true
    export_environment_variables: true
    cleanup_credentials: true
    access_token_lifetime: 3600s
    access_token_scopes: https://www.googleapis.com/auth/cloud-platform
    retries: 0
    id_token_include_email: false
Error: google-github-actions/auth failed with: retry function failed after 1 attempt: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely means the GitHub Actions workflow permissions are incorrect, or this job is being run from a fork. For more information, please see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
```

Error fixed after I added permissions in my own workflow, so I think the basic example could add these lines