### PR TITLE
Release v5

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -7,9 +7,24 @@ on:
     branches:
       - master
 jobs:
+  metadata:
+    name: Workflow metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Job summary
+        run: |
+          echo "## Workflow Run Info" >> $GITHUB_STEP_SUMMARY
+          echo "| Key | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | ----- |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Commit** | [\`${GITHUB_SHA::7}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Branch** | \`${{ github.ref_name }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Event** | \`${{ github.event_name }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Actor** | @${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY
+
   # example with Workload Identity Federation
   build-and-push-to-gcr-workload-identity:
     name: Build & push - with workload identity
+    needs: metadata
     runs-on: ubuntu-latest
     permissions: # <- this section is needed for workload identity
       contents: 'read'
@@ -37,6 +52,7 @@ jobs:
   # example with gcloud service account key
   build-and-push-to-gcr-service-account:
     name: Build & push - with service account
+    needs: metadata
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -57,9 +73,10 @@ jobs:
           dockerfile: ./test/Dockerfile.test
           context: ./test
           target: build
-  # example with gcloud service account key, except using google-github-actions/auth step. the login is handled by this action 
+  # example with gcloud service account key, except using google-github-actions/auth step. the login is handled by this action
   build-and-push-to-gcr-without-gcloud-auth-action:
     name: Build & push - without gcloud auth action
+    needs: metadata
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -78,6 +95,7 @@ jobs:
   # example with push-only
   push-only-image:
     name: Push only - with workload identity
+    needs: metadata
     runs-on: ubuntu-latest
     permissions: # <- this section is needed for workload identity
       contents: 'read'

--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -24,7 +24,7 @@ jobs:
           service_account: push-to-gcr-storage-object-adm@oss-projects-487304.iam.gserviceaccount.com
       - name: Building and pushing the image
         uses: ./
-        # uses: RafikFarhad/push-to-gcr-github-action@v5-rc1 # <- use this on your workflow
+        # uses: RafikFarhad/push-to-gcr-github-action@v5 # <- use this on your workflow
         with:
           # gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }} # <- not needed when used with google-github-actions/auth@v2
           registry: gcr.io
@@ -47,7 +47,7 @@ jobs:
           credentials_json: '${{ secrets.B64_GCLOUD_SERVICE_ACCOUNT_JSON }}'
       - name: Building and pushing the image
         uses: ./
-        # uses: RafikFarhad/push-to-gcr-github-action@v5-rc1 # <- use this on your workflow
+        # uses: RafikFarhad/push-to-gcr-github-action@v5 # <- use this on your workflow
         with:
           # gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }} # <- not needed when used with google-github-actions/auth@v2
           registry: gcr.io
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Building and pushing the image
         uses: ./
-        # uses: RafikFarhad/push-to-gcr-github-action@v5-rc1 # <- use this on your workflow
+        # uses: RafikFarhad/push-to-gcr-github-action@v5 # <- use this on your workflow
         with:
           gcloud_service_key: "${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }}"
           registry: gcr.io
@@ -96,7 +96,7 @@ jobs:
           service_account: push-to-gcr-storage-object-adm@oss-projects-487304.iam.gserviceaccount.com
       - name: Pushing the image
         uses: ./
-        # uses: RafikFarhad/push-to-gcr-github-action@v5-rc1 # <- use this on your workflow
+        # uses: RafikFarhad/push-to-gcr-github-action@v5 # <- use this on your workflow
         with:
           # gcloud_service_key: ${{ secrets.JSON_GCLOUD_SERVICE_ACCOUNT_JSON }} # <- not needed when used with google-github-actions/auth@v2
           registry: gcr.io

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -77,7 +77,7 @@ jobs:
         with:
           workload_identity_provider: projects/123123123/locations/global/workloadIdentityPools/the-workload-pool/providers/the-provider
           service_account: artifact-registry-writer@<PROJECT_ID>.iam.gserviceaccount.com
-      - uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+      - uses: RafikFarhad/push-to-gcr-github-action@v5
         with:
           # gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }} # can be base64 encoded or plain text || not needed if you use google-github-actions/auth
           registry: gcr.io

--- a/action.yaml
+++ b/action.yaml
@@ -45,4 +45,4 @@ inputs:
     default: false
 runs:
   using: docker
-  image: docker://ghcr.io/rafikfarhad/push-to-gcr-action:1.2.0
+  image: docker://ghcr.io/rafikfarhad/push-to-gcr-action:1.3.0

--- a/examples/build-on-push-event.yml
+++ b/examples/build-on-push-event.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+      - uses: RafikFarhad/push-to-gcr-github-action@v5
         with:
           gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
           registry: gcr.io

--- a/examples/build-on-tags.yml
+++ b/examples/build-on-tags.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Get the tag name
         id: get_tag_name
         run: echo ::set-output name=GIT_TAG_NAME::${GITHUB_REF/refs\/tags\//}
-      - uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+      - uses: RafikFarhad/push-to-gcr-github-action@v5
         with:
           gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
           registry: gcr.io

--- a/examples/no-build-only-push.yml
+++ b/examples/no-build-only-push.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: RafikFarhad/push-to-gcr-github-action@v5-rc1
+      - uses: RafikFarhad/push-to-gcr-github-action@v5
         with:
           gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
           registry: gcr.io


### PR DESCRIPTION
## Summary
- Updated all action references from `v5-rc1` to `v5` across README, examples, and CI workflow
- Bumped action container image from `1.2.0` to `1.3.0`

## Changes
- **ReadMe.md**: `@v5-rc1` → `@v5`
- **examples/**: All 3 example workflows updated to `@v5`
- **.github/workflows/build_and_push.yaml**: All commented references updated to `@v5`
- **action.yaml**: Image updated to `ghcr.io/rafikfarhad/push-to-gcr-action:1.3.0`

## Test plan
- [x] CI workflow passes on this PR
- [x] Verify image `1.3.0` is published to GHCR
- [ ] Tag `v5` after merge

Disclaimer: This commit had a helpful chat with an LLM.